### PR TITLE
[FEAT] 개인정보 암호화 기능 추가

### DIFF
--- a/src/main/java/com/example/project/application/auth/LoginService.java
+++ b/src/main/java/com/example/project/application/auth/LoginService.java
@@ -4,6 +4,7 @@ import com.example.project.application.auth.exception.EmailVerificationNotComple
 import com.example.project.application.auth.exception.LoginFailException;
 import com.example.project.application.auth.usecase.LoginCommand;
 import com.example.project.application.auth.usecase.LoginUseCase;
+import com.example.project.application.common.TwoWayEncryptor;
 import com.example.project.application.user.usecase.OneWayEncryptor;
 import com.example.project.domain.user.model.User;
 import com.example.project.domain.user.repository.UserRepository;
@@ -16,10 +17,11 @@ public class LoginService implements LoginUseCase {
 
   private final UserRepository userRepository;
   private final OneWayEncryptor oneWayEncryptor;
+  private final TwoWayEncryptor twoWayEncryptor;
 
   @Override
   public User apply(LoginCommand command) {
-    User user = findUser(command.email());
+    User user = findUser(twoWayEncryptor.encrypt(command.email()));
     checkPassword(command.password(), user.getPassword());
 
     // 이메일 인증이 완료되지 않은 경우 로그인 불가

--- a/src/main/java/com/example/project/application/common/TwoWayEncryptor.java
+++ b/src/main/java/com/example/project/application/common/TwoWayEncryptor.java
@@ -1,0 +1,9 @@
+package com.example.project.application.common;
+
+public interface TwoWayEncryptor {
+
+  String encrypt(String rawText);
+
+  String decrypt(String cipherText);
+
+}

--- a/src/main/java/com/example/project/application/user/SignUpService.java
+++ b/src/main/java/com/example/project/application/user/SignUpService.java
@@ -1,5 +1,6 @@
 package com.example.project.application.user;
 
+import com.example.project.application.common.TwoWayEncryptor;
 import com.example.project.application.user.exception.DuplicatedEmailException;
 import com.example.project.application.user.usecase.OneWayEncryptor;
 import com.example.project.application.user.usecase.SignUpCommand;
@@ -21,22 +22,23 @@ public class SignUpService implements SignUpUseCase {
   private final UserRepository userRepository;
   private final AddressRepository addressRepository;
   private final OneWayEncryptor oneWayEncryptor;
+  private final TwoWayEncryptor twoWayEncryptor;
 
   @Override
   @Transactional
   public User apply(SignUpCommand signUpCommand) {
     // 이메일 중복 확인
-    checkEmailDuplicate(signUpCommand.email());
+    checkEmailDuplicate(twoWayEncryptor.encrypt(signUpCommand.email()));
 
     // 패스워드 암호화
     String encodedPassword = oneWayEncryptor.encode(signUpCommand.password());
     // 개인 정보 암호화
     // 유저, 주소 저장
     User user = User.builder()
-                    .email(signUpCommand.email())
+                    .email(twoWayEncryptor.encrypt(signUpCommand.email()))
                     .password(encodedPassword)
-                    .username(signUpCommand.username())
-                    .phoneNum(signUpCommand.phoneNum())
+                    .username(twoWayEncryptor.encrypt(signUpCommand.username()))
+                    .phoneNum(twoWayEncryptor.encrypt(signUpCommand.phoneNum()))
                     .userStatus(UserStatus.REQUEST_APPROVAL)
                     .userRole(UserRole.ROLE_BUYER)
                     .build();
@@ -44,9 +46,9 @@ public class SignUpService implements SignUpUseCase {
     User savedUser = userRepository.save(user);
 
     Address address = Address.builder()
-                             .zipcode(signUpCommand.zipcode())
-                             .addressMain(signUpCommand.addressMain())
-                             .addressSub(signUpCommand.addressSub())
+                             .zipcode(twoWayEncryptor.encrypt(signUpCommand.zipcode()))
+                             .addressMain(twoWayEncryptor.encrypt(signUpCommand.addressMain()))
+                             .addressSub(twoWayEncryptor.encrypt(signUpCommand.addressSub()))
                              .user(savedUser)
                              .build();
 

--- a/src/main/java/com/example/project/config/SecurityConfig.java
+++ b/src/main/java/com/example/project/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.project.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,12 +10,25 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
+
+  private final String password;
+  private final String salt;
+
+  public SecurityConfig(
+      @Value("${encryptor.password}") String password,
+      @Value("${encryptor.salt}") String salt
+  ) {
+    this.password = password;
+    this.salt = salt;
+  }
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -30,6 +44,11 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable);
 
     return http.build();
+  }
+
+  @Bean
+  public BytesEncryptor bytesEncryptor() {
+    return new AesBytesEncryptor(password, salt);
   }
 
   @Bean

--- a/src/main/java/com/example/project/domain/user/model/Address.java
+++ b/src/main/java/com/example/project/domain/user/model/Address.java
@@ -26,7 +26,7 @@ public class Address {
   @JoinColumn(name = "user_id")
   private User user;
 
-  @Column(nullable = false, columnDefinition = "char(5)")
+  @Column(nullable = false, columnDefinition = "char(24)")
   private String zipcode;
 
   @Column(nullable = false)

--- a/src/main/java/com/example/project/domain/user/model/User.java
+++ b/src/main/java/com/example/project/domain/user/model/User.java
@@ -22,7 +22,7 @@ public class User extends BaseTime {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long userId;
 
-  @Column(nullable = false, columnDefinition = "char(10)")
+  @Column(nullable = false, columnDefinition = "char(50)")
   private String username;
 
   @Column(nullable = false)
@@ -31,7 +31,7 @@ public class User extends BaseTime {
   @Column(nullable = false)
   private String email;
 
-  @Column(nullable = false, columnDefinition = "char(13)")
+  @Column(nullable = false, columnDefinition = "char(24)")
   private String phoneNum;
 
   @Column(nullable = false, columnDefinition = "varchar")

--- a/src/main/java/com/example/project/infrastructure/security/TwoWayEncryptorAdapter.java
+++ b/src/main/java/com/example/project/infrastructure/security/TwoWayEncryptorAdapter.java
@@ -1,0 +1,30 @@
+package com.example.project.infrastructure.security;
+
+import com.example.project.application.common.TwoWayEncryptor;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TwoWayEncryptorAdapter implements TwoWayEncryptor {
+
+  private final BytesEncryptor bytesEncryptor;
+
+  @Override
+  public String encrypt(String rawText) {
+    byte[] bytes = rawText.getBytes();
+    byte[] encryptedBytes = bytesEncryptor.encrypt(bytes);
+
+    return Base64.getEncoder().encodeToString(encryptedBytes);
+  }
+
+  @Override
+  public String decrypt(String cipherText) {
+    byte[] bytes = Base64.getDecoder().decode(cipherText);
+    byte[] decryptedBytes = bytesEncryptor.decrypt(bytes);
+
+    return new String(decryptedBytes);
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,10 @@ logging:
 jwt:
   secret: e-commerce-secret-key-for-local-project
 
+encryptor:
+  password: ecommerce-password
+  salt: deadbeef
+
 management:
   endpoints:
     web:

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS user
 (
     user_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    username    CHAR(10)        NOT NULL,
+    username    CHAR(50)        NOT NULL,
     password    VARCHAR(255)    NOT NULL,
     email       VARCHAR(255)    NOT NULL UNIQUE,
-    phone_num   CHAR(13)        NOT NULL,
+    phone_num   CHAR(24)        NOT NULL,
     user_role   VARCHAR(255)    NOT NULL,
     user_status VARCHAR(255)    NOT NULL,
     created_at  TIMESTAMP       NOT NULL,
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS user
 CREATE TABLE IF NOT EXISTS address
 (
     address_id   BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    zipcode      CHAR(5)        NOT NULL,
+    zipcode      CHAR(24)        NOT NULL,
     address_main VARCHAR(255)    NOT NULL,
     address_sub  VARCHAR(255)    NOT NULL,
     is_default   TINYINT(1)      NOT NULL,


### PR DESCRIPTION
### 구현 내용

1. AES 256 CBC 알고리즘을 이용한 개인정보 암호화, 복호화 기능 추가 
  - spring 에서 권장하는 GCM 알고리즘을 사용하려 했으나, IV 랜덤 생성으로 같은 평문이라도 암호화 할때마다 결과가 달라져 DB 검색 불가


2. 암호화, Base64 인코딩 후 길이를 고려해 개인 정보 컬럼 길이 수정
  - CBC 암호화 길이 공식 : (평문/16 + 1 ) * 16 // 내림
  - Base64 인코딩 길이 공식 : ( 평문 / 3) * 4 // 올림 

closed #4 