### PR TITLE
[FEAT] 인증 인가를 위한 Filter 추가

### DIFF
--- a/src/main/java/com/example/project/config/SecurityConfig.java
+++ b/src/main/java/com/example/project/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.project.config;
 
+import com.example.project.infrastructure.security.filter.JwtFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -13,7 +14,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
 import org.springframework.security.crypto.encrypt.BytesEncryptor;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
@@ -21,27 +25,40 @@ public class SecurityConfig {
 
   private final String password;
   private final String salt;
+  private final JwtFilter jwtFilter;
+  private final AccessDeniedHandler accessDeniedHandler;
+  private final AuthenticationEntryPoint authenticationEntryPoint;
 
   public SecurityConfig(
       @Value("${encryptor.password}") String password,
-      @Value("${encryptor.salt}") String salt
+      @Value("${encryptor.salt}") String salt,
+      JwtFilter jwtFilter,
+      AccessDeniedHandler accessDeniedHandler,
+      AuthenticationEntryPoint authenticationEntryPoint
   ) {
     this.password = password;
     this.salt = salt;
+    this.jwtFilter = jwtFilter;
+    this.accessDeniedHandler = accessDeniedHandler;
+    this.authenticationEntryPoint = authenticationEntryPoint;
   }
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(sessionManager -> sessionManager
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/signup", "/auth/login", "/actuator/**", "/", "/error").permitAll()
             .anyRequest().authenticated()
         )
-        .httpBasic(AbstractHttpConfigurer::disable)
-        .formLogin(AbstractHttpConfigurer::disable)
-        .csrf(AbstractHttpConfigurer::disable);
+        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(exceptionHandling -> exceptionHandling
+            .authenticationEntryPoint(authenticationEntryPoint)
+            .accessDeniedHandler(accessDeniedHandler));
 
     return http.build();
   }

--- a/src/main/java/com/example/project/infrastructure/JwtProvider.java
+++ b/src/main/java/com/example/project/infrastructure/JwtProvider.java
@@ -1,6 +1,8 @@
 package com.example.project.infrastructure;
 
 import com.example.project.domain.user.model.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -49,5 +51,22 @@ public class JwtProvider {
                .setIssuedAt(now)
                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME))
                .signWith(getSigningKey(), SignatureAlgorithm.HS256).compact();
+  }
+
+  public void validateToken(String token) throws JwtException, IllegalArgumentException {
+    getClaimsFromToken(token);
+  }
+
+  public String getSubjectFromToken(String token) {
+    return getClaimsFromToken(token).getSubject();
+  }
+
+  public String getRoleFromToken(String token) {
+    return getClaimsFromToken(token).get("role").toString();
+  }
+
+  private Claims getClaimsFromToken(String token) {
+    return Jwts.parserBuilder().setSigningKey(getSigningKey()).build()
+               .parseClaimsJws(token).getBody();
   }
 }

--- a/src/main/java/com/example/project/infrastructure/security/filter/JwtFilter.java
+++ b/src/main/java/com/example/project/infrastructure/security/filter/JwtFilter.java
@@ -1,0 +1,73 @@
+package com.example.project.infrastructure.security.filter;
+
+import com.example.project.infrastructure.JwtProvider;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+  private final JwtProvider jwtProvider;
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String AUTHORIZATION_TYPE = "Bearer ";
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String jwtToken = getJwtFromRequest(request);
+
+    try {
+      jwtProvider.validateToken(jwtToken);
+      UserDetails userDetails = getUserDetails(jwtProvider.getSubjectFromToken(jwtToken),
+          jwtProvider.getRoleFromToken(jwtToken));
+      Authentication authentication = getAuthentication(userDetails);
+
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    } catch (JwtException | IllegalArgumentException e) {
+      log.info("Exception : {}, Message : {}", e.getClass(), e.getMessage());
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String[] excludePath = {"/api/signup", "/api/auth/login"};
+    String path = request.getRequestURI();
+    return Arrays.stream(excludePath).anyMatch(path::equals);
+  }
+
+  private String getJwtFromRequest(HttpServletRequest request) {
+    String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(AUTHORIZATION_TYPE)) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+
+  private Authentication getAuthentication(UserDetails userDetails) {
+    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+  }
+
+  private UserDetails getUserDetails(String userId, String role) {
+    return User.builder().username(userId).password("").authorities(role).build();
+
+  }
+}

--- a/src/main/java/com/example/project/infrastructure/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/project/infrastructure/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.example.project.infrastructure.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    response.sendError(HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
+  }
+}

--- a/src/main/java/com/example/project/infrastructure/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/project/infrastructure/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.example.project.infrastructure.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+    response.sendError(HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
+  }
+}

--- a/src/main/java/com/example/project/presentation/user/controller/MyPageController.java
+++ b/src/main/java/com/example/project/presentation/user/controller/MyPageController.java
@@ -1,0 +1,16 @@
+package com.example.project.presentation.user.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MyPageController {
+
+  @GetMapping("/my-page")
+  public String myPage(@AuthenticationPrincipal UserDetails userDetails){
+    System.out.println(userDetails.getUsername());
+    return "hi";
+  }
+}


### PR DESCRIPTION
### 구현 내용

인증 인가를 위한 Filter를 추가했습니다
최상단에 JwtFilter 추가로 API 요청을 처리해 인증객체를 저장, 인증 인가를 처리할 수 있게 합니다.
- 인증 에러 응답을 위한 AuthenticationEntryPoint
- 인가 에러 응답을 위한 AccessDeniedHandler 

클래스를 추가해 에러상황시 응답을 처리합니다. 사용자에게 자세한 에러내용을 알려줄 필요가 없다 판단해 응답을 통일시켰고 자세한 내용은 서버에 log만 남기도록 했습니다.