### PR TITLE
[FEAT] 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/example/project/application/user/ChangePasswordService.java
+++ b/src/main/java/com/example/project/application/user/ChangePasswordService.java
@@ -1,0 +1,41 @@
+package com.example.project.application.user;
+
+import com.example.project.application.user.exception.PasswordMismatchException;
+import com.example.project.application.user.exception.UserNotFoundException;
+import com.example.project.application.user.usecase.ChangePasswordCommand;
+import com.example.project.application.user.usecase.ChangePasswordUseCase;
+import com.example.project.application.user.usecase.OneWayEncryptor;
+import com.example.project.domain.user.model.User;
+import com.example.project.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChangePasswordService implements ChangePasswordUseCase {
+
+  private final UserRepository userRepository;
+  private final OneWayEncryptor oneWayEncryptor;
+
+  @Override
+  @Transactional
+  public void accept(ChangePasswordCommand command) {
+    User user = findUser(command.userId());
+
+    checkPassword(command.originalPassword(), user.getPassword());
+    user.changePassword(oneWayEncryptor.encode(command.newPassword()));
+  }
+
+  private void checkPassword(String rawPassword, String encodedPassword) {
+    if (!oneWayEncryptor.match(rawPassword, encodedPassword)) {
+      throw new PasswordMismatchException();
+    }
+  }
+
+  private User findUser(Long userId) {
+    return userRepository.findById(userId)
+                         .orElseThrow(UserNotFoundException::new);
+  }
+
+}

--- a/src/main/java/com/example/project/application/user/GetMyPageService.java
+++ b/src/main/java/com/example/project/application/user/GetMyPageService.java
@@ -1,6 +1,7 @@
 package com.example.project.application.user;
 
 import com.example.project.application.common.TwoWayEncryptor;
+import com.example.project.application.user.exception.UserNotFoundException;
 import com.example.project.application.user.usecase.GetMyPageUseCase;
 import com.example.project.application.user.usecase.MyPageInfo;
 import com.example.project.domain.user.model.Address;
@@ -28,7 +29,7 @@ public class GetMyPageService implements GetMyPageUseCase {
 
   private User findUser(Long userId) {
     return userRepository.findById(userId)
-                         .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                         .orElseThrow(() -> new UserNotFoundException());
   }
 
   private User decryptUser(User user) {

--- a/src/main/java/com/example/project/application/user/exception/PasswordMismatchException.java
+++ b/src/main/java/com/example/project/application/user/exception/PasswordMismatchException.java
@@ -1,0 +1,10 @@
+package com.example.project.application.user.exception;
+
+import com.example.project.presentation.common.error.BusinessException;
+
+public class PasswordMismatchException extends BusinessException {
+
+  public PasswordMismatchException() {
+    super(UserErrorCode.PASSWORD_MISMATCH);
+  }
+}

--- a/src/main/java/com/example/project/application/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/project/application/user/exception/UserErrorCode.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
-  DUPLICATED_EMAIL("U001", "중복된 이메일입니다.");
+  DUPLICATED_EMAIL("U001", "중복된 이메일입니다."),
+  USER_NOT_FOUND("U002", "존재하지 않는 회원입니다."),
+  PASSWORD_MISMATCH("U003", "비밀번호가 일치하지 않습니다.");
 
   private final String code;
   private final String message;

--- a/src/main/java/com/example/project/application/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/project/application/user/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.project.application.user.exception;
+
+import com.example.project.presentation.common.error.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+
+  public UserNotFoundException() {
+    super(UserErrorCode.USER_NOT_FOUND);
+  }
+
+}

--- a/src/main/java/com/example/project/application/user/usecase/ChangePasswordCommand.java
+++ b/src/main/java/com/example/project/application/user/usecase/ChangePasswordCommand.java
@@ -1,0 +1,9 @@
+package com.example.project.application.user.usecase;
+
+public record ChangePasswordCommand(
+    Long userId,
+    String originalPassword,
+    String newPassword
+) {
+
+}

--- a/src/main/java/com/example/project/application/user/usecase/ChangePasswordUseCase.java
+++ b/src/main/java/com/example/project/application/user/usecase/ChangePasswordUseCase.java
@@ -1,0 +1,7 @@
+package com.example.project.application.user.usecase;
+
+import java.util.function.Consumer;
+
+public interface ChangePasswordUseCase extends Consumer<ChangePasswordCommand> {
+
+}

--- a/src/main/java/com/example/project/domain/user/model/User.java
+++ b/src/main/java/com/example/project/domain/user/model/User.java
@@ -46,6 +46,10 @@ public class User extends BaseTime {
     return userStatus.equals(UserStatus.APPROVED);
   }
 
+  public void changePassword(String newPassword) {
+    this.password = newPassword;
+  }
+
   @Builder
   public User(Long userId, String username, String password, String email, String phoneNum,
       UserRole userRole, UserStatus userStatus) {

--- a/src/main/java/com/example/project/presentation/user/controller/ChangePasswordController.java
+++ b/src/main/java/com/example/project/presentation/user/controller/ChangePasswordController.java
@@ -1,0 +1,25 @@
+package com.example.project.presentation.user.controller;
+
+import com.example.project.application.user.usecase.ChangePasswordUseCase;
+import com.example.project.presentation.user.dto.request.ChangePasswordRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChangePasswordController {
+
+  private final ChangePasswordUseCase changePasswordUseCase;
+
+  @PatchMapping("/user/password")
+  public void changePassword(@RequestBody @Valid ChangePasswordRequest changePasswordRequest,
+      @AuthenticationPrincipal UserDetails userDetails) {
+    Long userId = Long.valueOf(userDetails.getUsername());
+    changePasswordUseCase.accept(changePasswordRequest.toCommand(userId));
+  }
+}

--- a/src/main/java/com/example/project/presentation/user/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/example/project/presentation/user/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,20 @@
+package com.example.project.presentation.user.dto.request;
+
+import com.example.project.application.user.usecase.ChangePasswordCommand;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+
+public record ChangePasswordRequest(
+    @NotEmpty
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*\\W)(?=\\S+$).{8,15}$", message = "올바른 비밀번호 형식이 아닙니다.")
+    String originalPassword,
+
+    @NotEmpty
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*\\W)(?=\\S+$).{8,15}$", message = "올바른 비밀번호 형식이 아닙니다.")
+    String newPassword
+) {
+
+  public ChangePasswordCommand toCommand(Long userId) {
+    return new ChangePasswordCommand(userId, originalPassword, newPassword);
+  }
+}


### PR DESCRIPTION
## 구현 내용
유저의 비밀번호를 변경하는 API 를 구현
- ID에 해당하는 유저가 존재하지 않을시 UserNotFoundException 발생
- 원래 비밀번호가 일치하지 않을시 PasswordMismatchException 발생

이후 비밀번호 변경시 모든기기 로그아웃 기능 필요

closed #11 