### PR TITLE
[FEAT] 주소 수정 구현

### DIFF
--- a/src/main/java/com/example/project/application/user/UpdateAddressService.java
+++ b/src/main/java/com/example/project/application/user/UpdateAddressService.java
@@ -1,0 +1,58 @@
+package com.example.project.application.user;
+
+import com.example.project.application.common.TwoWayEncryptor;
+import com.example.project.application.user.exception.AddressNotFoundException;
+import com.example.project.application.user.exception.UserMismatchException;
+import com.example.project.application.user.usecase.UpdateAddressCommand;
+import com.example.project.application.user.usecase.UpdateAddressUseCase;
+import com.example.project.domain.user.model.Address;
+import com.example.project.domain.user.repository.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateAddressService implements UpdateAddressUseCase {
+
+  private final AddressRepository addressRepository;
+  private final TwoWayEncryptor twoWayEncryptor;
+
+  @Override
+  @Transactional
+  public Address apply(UpdateAddressCommand command) {
+    Address address = findAddress(command.addressId());
+
+    if (!address.isSameUser(command.userId())) {
+      throw new UserMismatchException();
+    }
+
+    // 기존 default address를 false로 변경
+    if (!address.isDefault() && command.isDefault()) {
+      addressRepository.updateDefaultAddress(command.userId());
+    }
+
+    address.updateAddress(
+        twoWayEncryptor.encrypt(command.zipcode()),
+        twoWayEncryptor.encrypt(command.addressMain()),
+        twoWayEncryptor.encrypt(command.addressSub()),
+        command.isDefault());
+
+    return decryptAddress(address);
+  }
+
+  private Address findAddress(Long addressId) {
+    return addressRepository.findById(addressId)
+                            .orElseThrow(AddressNotFoundException::new);
+  }
+
+  private Address decryptAddress(Address address) {
+    return Address.builder()
+                  .addressId(address.getAddressId())
+                  .zipcode(twoWayEncryptor.decrypt(address.getZipcode()))
+                  .addressMain(twoWayEncryptor.decrypt(address.getAddressMain()))
+                  .addressSub(twoWayEncryptor.decrypt(address.getAddressSub()))
+                  .isDefault(address.isDefault())
+                  .build();
+  }
+}

--- a/src/main/java/com/example/project/application/user/exception/AddressNotFoundException.java
+++ b/src/main/java/com/example/project/application/user/exception/AddressNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.project.application.user.exception;
+
+import com.example.project.presentation.common.error.BusinessException;
+
+public class AddressNotFoundException extends BusinessException {
+
+  public AddressNotFoundException() {
+    super(UserErrorCode.ADDRESS_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/example/project/application/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/project/application/user/exception/UserErrorCode.java
@@ -9,7 +9,9 @@ public enum UserErrorCode implements ErrorCode {
 
   DUPLICATED_EMAIL("U001", "중복된 이메일입니다.", 400),
   USER_NOT_FOUND("U002", "존재하지 않는 회원입니다.", 404),
-  PASSWORD_MISMATCH("U003", "비밀번호가 일치하지 않습니다.", 400);
+  PASSWORD_MISMATCH("U003", "비밀번호가 일치하지 않습니다.", 400),
+  ADDRESS_NOT_FOUND("U004", "존재하지 않는 주소입니다.", 404),
+  USER_MISMATCH("U005", "회원 정보가 일치하지 않습니다.", 400);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/example/project/application/user/exception/UserMismatchException.java
+++ b/src/main/java/com/example/project/application/user/exception/UserMismatchException.java
@@ -1,0 +1,9 @@
+package com.example.project.application.user.exception;
+
+import com.example.project.presentation.common.error.BusinessException;
+
+public class UserMismatchException extends BusinessException {
+  public UserMismatchException() {
+    super(UserErrorCode.USER_MISMATCH);
+  }
+}

--- a/src/main/java/com/example/project/application/user/usecase/UpdateAddressCommand.java
+++ b/src/main/java/com/example/project/application/user/usecase/UpdateAddressCommand.java
@@ -1,0 +1,12 @@
+package com.example.project.application.user.usecase;
+
+public record UpdateAddressCommand(
+    Long userId,
+    Long addressId,
+    String zipcode,
+    String addressMain,
+    String addressSub,
+    boolean isDefault
+) {
+
+}

--- a/src/main/java/com/example/project/application/user/usecase/UpdateAddressUseCase.java
+++ b/src/main/java/com/example/project/application/user/usecase/UpdateAddressUseCase.java
@@ -1,0 +1,8 @@
+package com.example.project.application.user.usecase;
+
+import com.example.project.domain.user.model.Address;
+import java.util.function.Function;
+
+public interface UpdateAddressUseCase extends Function<UpdateAddressCommand, Address>{
+
+}

--- a/src/main/java/com/example/project/domain/user/model/Address.java
+++ b/src/main/java/com/example/project/domain/user/model/Address.java
@@ -38,6 +38,18 @@ public class Address {
   @Column(nullable = false, columnDefinition = "tinyint(1)")
   private boolean isDefault;
 
+  public boolean isSameUser(Long userId) {
+    return user.getUserId().equals(userId);
+  }
+
+  public void updateAddress(String zipcode, String addressMain, String addressSub,
+      boolean isDefault) {
+    this.zipcode = zipcode;
+    this.addressMain = addressMain;
+    this.addressSub = addressSub;
+    this.isDefault = isDefault;
+  }
+
   @Builder
   public Address(Long addressId, User user, String zipcode, String addressMain, String addressSub,
       boolean isDefault) {

--- a/src/main/java/com/example/project/domain/user/repository/AddressRepository.java
+++ b/src/main/java/com/example/project/domain/user/repository/AddressRepository.java
@@ -3,10 +3,15 @@ package com.example.project.domain.user.repository;
 import com.example.project.domain.user.model.Address;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface AddressRepository extends JpaRepository<Address, Long> {
 
   @Query("select a from Address a where a.user.userId = :userId")
   List<Address> findAllByUserId(Long userId);
+
+  @Modifying
+  @Query("update Address a set a.isDefault = false where a.user.userId = :userId and a.isDefault = true")
+  int updateDefaultAddress(Long userId);
 }

--- a/src/main/java/com/example/project/presentation/user/controller/UpdateAddressController.java
+++ b/src/main/java/com/example/project/presentation/user/controller/UpdateAddressController.java
@@ -1,0 +1,35 @@
+package com.example.project.presentation.user.controller;
+
+import com.example.project.application.user.usecase.UpdateAddressUseCase;
+import com.example.project.domain.user.model.Address;
+import com.example.project.presentation.user.dto.request.UpdateAddressRequest;
+import com.example.project.presentation.user.dto.response.UpdateAddressResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class UpdateAddressController {
+
+  private final UpdateAddressUseCase updateAddressUseCase;
+
+  @PatchMapping("/user/addresses/{addressId}")
+  public ResponseEntity<UpdateAddressResponse> updateAddress(
+      @PathVariable @Min(1) Long addressId,
+      @Valid @RequestBody UpdateAddressRequest updateAddressRequest,
+      @AuthenticationPrincipal UserDetails userDetails) {
+    Long userId = Long.valueOf(userDetails.getUsername());
+    Address address = updateAddressUseCase.apply(updateAddressRequest.toCommand(userId, addressId));
+    return ResponseEntity.ok(UpdateAddressResponse.of(address));
+  }
+}

--- a/src/main/java/com/example/project/presentation/user/dto/request/UpdateAddressRequest.java
+++ b/src/main/java/com/example/project/presentation/user/dto/request/UpdateAddressRequest.java
@@ -1,0 +1,20 @@
+package com.example.project.presentation.user.dto.request;
+
+import com.example.project.application.user.usecase.UpdateAddressCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateAddressRequest(
+
+    @NotBlank
+    String zipcode,
+    @NotBlank
+    String addressMain,
+    @NotBlank
+    String addressSub,
+    boolean isDefault
+) {
+
+  public UpdateAddressCommand toCommand(Long userId, Long addressId) {
+    return new UpdateAddressCommand(userId, addressId, zipcode, addressMain, addressSub, isDefault);
+  }
+}

--- a/src/main/java/com/example/project/presentation/user/dto/response/UpdateAddressResponse.java
+++ b/src/main/java/com/example/project/presentation/user/dto/response/UpdateAddressResponse.java
@@ -1,0 +1,22 @@
+package com.example.project.presentation.user.dto.response;
+
+import com.example.project.domain.user.model.Address;
+
+public record UpdateAddressResponse(
+    Long addressId,
+    String zipcode,
+    String addressMain,
+    String addressSub,
+    boolean isDefault
+) {
+
+  public static UpdateAddressResponse of(Address address) {
+    return new UpdateAddressResponse(
+        address.getAddressId(),
+        address.getZipcode(),
+        address.getAddressMain(),
+        address.getAddressSub(),
+        address.isDefault()
+    );
+  }
+}


### PR DESCRIPTION
## 구현 내용

유저의 주소 정보를 수정하는 API 구현
- 요청자와 수정할 주소의 연관관계가 맞지 않으면 UserMismatchException 예외 발생
- 요청의 isDefault 가 true인 경우 현재 수정하고자 하는 주소가 true가 아니라면 기존 true의 주소를 false로 변경, 수정하고자 하는 주소의 default를 true로 변경

closed #19 